### PR TITLE
Fix errors in Explorer  empty folder and on Outlook attachments

### DIFF
--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -686,7 +686,11 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             return
         if hasattr(focus, "treeInterceptor") and hasattr(focus.treeInterceptor, "makeTextInfo"):
             focus = focus.treeInterceptor
-        textInfo = focus.makeTextInfo(textInfos.POSITION_CARET)
+        try:
+            textInfo = focus.makeTextInfo(textInfos.POSITION_CARET)
+        except NotImplementedError:
+            gesture.send()
+            return
         caretIndex = getCaretIndexWithinParagraph(textInfo)
         textInfo.expand(textInfos.UNIT_PARAGRAPH)
         reconstructMode = getConfig("reconstructMode")


### PR DESCRIPTION
Hello Tony

Here is a quick fix for the two following use cases (and maybe many other):

## Windows Explorer use case

### STR:

* Open an empty folder
* Press Alt+UpArrow to turn back to parent folder

### Actual result

Error sound is heard and error is seen in the log. The gesture is not passed to the application so the parent folder is not re-opened.

### Expected result

No error sound. And go back to parent folder succeeds.

## Outlook (2016) use case

### STR:

* Open a message containing attachments
* Tab back in order to focus an attachment
* Press Alt+DownArrow to open the attachment's menu

### Actual result

Error sound is heard and error is seen in the log. The gesture is not passed to the application so the menu is not opened.

### Expected result

No error sound. And menu succeed in being opened.

## Notes

* It is just a proposal. You may find another implementation to fix these issues if you feel more adapted.
* Fixes #8 

Cheers

Cyrille

