### PR TITLE
Restricts compatibility to NVDA 2019.3 onwards

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -28,7 +28,7 @@ SentenceNav is an NVDA add-on that allows you to read text by sentences, as oppo
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3")
-	"addon_minimumNVDAVersion" : "2019.2.0",
+	"addon_minimumNVDAVersion" : "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion" : "2022.1.0",
 	# Add-on update channel (default is stable or None)


### PR DESCRIPTION
### Link to issue
Closes #22
### Issue description
Errors when running sentence nav with NVDA 2019.2.

### Solution
Update compa to NVDA 2019.3 onwards since the code already uses Python 3 syntax and will use it always more:
* print function
* f-strings

IMO there is no use to keep maintaining Python 2 code.
Someone using NVDA 2019.2 may still use older versions of SentenceNav.

