### PR TITLE
Maintenance PR

### DIFF
--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -124,11 +124,14 @@ def getCurrentLanguage():
     return s[:2]
 
 addonHandler.initTranslation()
+
+ADDON_SUMMARY = addonHandler.getCodeAddon().manifest["summary"]
+
 initConfiguration()
 
 class SettingsDialog(SettingsPanel):
     # Translators: Title for the settings dialog
-    title = _("SentenceNav settings")
+    title = ADDON_SUMMARY
 
     reconstructOptions = ["always", "sameIndent", "never"]
     # Translators: choices inside reconstruct mode combo box
@@ -240,7 +243,7 @@ class SettingsDialog(SettingsPanel):
         config.conf["sentencenav"]["fullWidthPhraseBreakers"] = self.fullWidthPhraseBreakersEdit.Value
         config.conf["sentencenav"]["applicationsBlacklist"] = self.applicationsBlacklistEdit.Value
         config.conf["sentencenav"]["enableInWord"] = self.enableInWordCheckbox.Value
-        global regexCache, phraseRegex
+
         regexCache.clear()
         phraseRegex = None
 
@@ -576,7 +579,7 @@ def getPhraseRegex():
     return result
 
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
-    scriptCategory = _("SentenceNav")
+    scriptCategory = ADDON_SUMMARY
 
     def __init__(self, *args, **kwargs):
         super(GlobalPlugin, self).__init__(*args, **kwargs)

--- a/buildVars.py
+++ b/buildVars.py
@@ -30,7 +30,7 @@ SentenceNav is an NVDA add-on that allows you to read text by sentences, as oppo
 	# Minimum NVDA version supported (e.g. "2018.3")
 	"addon_minimumNVDAVersion" : "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2022.1.0",
+	"addon_lastTestedNVDAVersion" : "2023.1.0",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }


### PR DESCRIPTION
Hi Tony

This is a maintenance PR for SentenceNav add-on. It includes two changes described below:

### Change 1: Use the add-on's name as category for scripts and settings window
In the settings Window, the settings panel for this add-on could be activated thanks to the category "SentenceNav settings". This text probably dates from the era when the multi-category dialog was not there and was probably the title of a settings dialog for this add-on. However, it does not make sense now to repeat "X settings" or "Y settings" for each category of the multi-category settings dialog. Translated in French, it's still worse since the texte reads "Paramètres SentenceNav", i.e. the word for "Settings" comes first. That's not adapted for first letter navigation in this list when someone would press S and expect to jump to SentenceNav settings.

Thus I have used the add-on's name instead (actually the field 'summary' in the manifest), i.e. just "SentenceNav".

###  Change 2: Update compatibility flag for NVDA 2023.1

I am running 2023.1rc1, rc2 and stable for some weeks with the manifest updated and have not found any issue with sentence navigation. I have also had a quick look to the code and have not seen any issue with respect to API-breaking changes of 2023.1. Thus I have updated the last tested version in this PR.


### Next

If you merge this PR, you can release a new version of this add-on; I do not know what is your process for releases.

If you wish, I may update the add-on on the website and the add-on store side if you make a release.
