### PR TITLE
Fix for that it's not reading the sentences at the very end.

### DIFF
--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -365,7 +365,16 @@ class Context:
         """
         start = self.makeTextInfo(startTi, startOffset)
         end = self.makeTextInfo(endTi, endOffset)
-        start.setEndPoint(end, "endToEnd")
+
+        # If the end of sentence is at the very end of the content,
+        # textInfos created by setEndPoint is bugged, so do it other way in that case.
+        if endOffset == len(startTi.text):
+            # This is expand(), defined in textInfos\offsets.py, but only to the end.
+            _, start._endOffset = start._getUnitOffsets(
+                textInfos.UNIT_PARAGRAPH, start._startOffset)
+        else:
+            start.setEndPoint(end, "endToEnd")
+            
         return start
 
     def isTouchingBoundary(self,direction, startTi, startOffset, endTi, endOffset):

--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -369,9 +369,8 @@ class Context:
         # If the end of sentence is at the very end of the content,
         # textInfos created by setEndPoint is bugged, so do it other way in that case.
         if endOffset == len(startTi.text):
-            # This is expand(), defined in textInfos\offsets.py, but only to the end.
-            _, start._endOffset = start._getUnitOffsets(
-                textInfos.UNIT_PARAGRAPH, start._startOffset)
+            start.move(textInfos.UNIT_CHARACTER, endOffset -
+                       startOffset, endPoint='end')
         else:
             start.setEndPoint(end, "endToEnd")
             


### PR DESCRIPTION
This is a fix for https://github.com/mltony/nvda-sentence-nav/issues/30.

The problem was that, when it calls setEndPoint in line 368,

start.setEndPoint(end, "endToEnd")

if end was the very end of the contents, it failed to create textInfos correctly, so the text inside the textInfos is empty.

And speech.speakTextInfo also fail to speak the textInfo.

This PR is fixing it by setting the end point in a different way.
You can try the difference in here.
https://mo29cg.github.io/

Thanks for reading.
