### PR TITLE
Auto turn page for Kindle

### DIFF
--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -709,7 +709,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
                 mylog(f"nextParagraph result == 0")
                 if shouldTurnPageIfNecessary:
                     # if there are no more paragraphs, check if we are in a document with page turns
-                    focus = api.getFocusObject()
+                    focus = textInfo.obj
                     if hasattr(focus, "treeInterceptor") and focus.treeInterceptor is not None and hasattr(focus.treeInterceptor, "makeTextInfo"):
                         focus = focus.treeInterceptor
                     # tested to work correctly in Kindle for PC

--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -694,6 +694,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
         """
             Advance to the next or previous paragraph depending on direction.
             Some hacks need to be performed to work around certain TextInfo implementation.
+
+            If shouldTurnPageIfNecessary=True, the returned paragraph might not be usable
+            in the same context as the input paragraph because if the page is turned, the
+            original paragraph is no longer readable.
         """
         mylog(f"nextParagraph direction={direction}")
         ti = textInfo.copy()

--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -710,8 +710,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
                 if shouldTurnPageIfNecessary:
                     # if there are no more paragraphs, check if we are in a document with page turns
                     focus = textInfo.obj
-                    if hasattr(focus, "treeInterceptor") and focus.treeInterceptor is not None and hasattr(focus.treeInterceptor, "makeTextInfo"):
-                        focus = focus.treeInterceptor
                     # tested to work correctly in Kindle for PC
                     # the other app that has DocumentWithPageTurns implemented is Adobe Digital Editions
                     # However, that app seems to work poorly with SentenceNav in general

--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -800,7 +800,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
                 if paragraph is None:
                     # if there are no more paragraphs, check if we are in a document with page turns
                     focus = api.getFocusObject()
-                    if hasattr(focus, "treeInterceptor") and hasattr(focus.treeInterceptor, "makeTextInfo"):
+                    if hasattr(focus, "treeInterceptor") and focus.treeInterceptor is not None and hasattr(focus.treeInterceptor, "makeTextInfo"):
                         focus = focus.treeInterceptor
                     # tested to work correctly in Kindle for PC
                     # the other app that has DocumentWithPageTurns implemented is Adobe Digital Editions
@@ -989,7 +989,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
             except AttributeError:
                 gesture.send()
             return
-        if hasattr(focus, "treeInterceptor") and hasattr(focus.treeInterceptor, "makeTextInfo"):
+        if hasattr(focus, "treeInterceptor") and focus.treeInterceptor is not None and hasattr(focus.treeInterceptor, "makeTextInfo"):
             focus = focus.treeInterceptor
         try:
             caretInfo = focus.makeTextInfo(textInfos.POSITION_CARET)

--- a/addon/globalPlugins/sentenceNav.py
+++ b/addon/globalPlugins/sentenceNav.py
@@ -802,7 +802,10 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
                     focus = api.getFocusObject()
                     if hasattr(focus, "treeInterceptor") and hasattr(focus.treeInterceptor, "makeTextInfo"):
                         focus = focus.treeInterceptor
-                    if isinstance(focus, textInfos.DocumentWithPageTurns):
+                    # tested to work correctly in Kindle for PC
+                    # the other app that has DocumentWithPageTurns implemented is Adobe Digital Editions
+                    # However, that app seems to work poorly with SentenceNav in general
+                    if isinstance(focus, textInfos.DocumentWithPageTurns) and 'kindle' in str(type(focus)):
                         try:
                             focus.turnPage(previous=direction < 0)
                         except RuntimeError:


### PR DESCRIPTION
closes #35 

When moving by sentence or phrase:
- moving forwards, when at the end of a page, automatically turns to next page and moves to the first sentence/phrase
- moving backwards, when at the beginning of a page, automatically turns to previous page and moves to last sentence/phrase
- if cannot turn to next because at the end/start of the book, chimes that there are no more sentences/phrases


I tried to make it generic so that it would support all applications where you turn a page. Currently, NVDA has implementations for Kindle for PC and Adobe Digital Editions. I tested with Kindle and ADE. With Kindle it works like a charm. However, with ADE it doesn't seem to work right. Although I had some trouble with ADE moving by sentence even without these changes, so there might be some general problems with the ADE implementation.

Currently, automatic page turn happens always when possible. There could be a config property for toggling this behavior. I figured though that this behavior is always preferable, since the other native movement types behave this way. But if you would like this to be configurable, let me know